### PR TITLE
Use lower version of compose and material3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,9 @@
 buildscript {
     ext {
-        compose_version = '1.6.0'
-        material3_version = "1.2.0-rc01"
+        compose_bom_version = '2023.06.01'
         constraint_layout_version = "1.0.1"
         dependency_analysis_version = "1.20.0"
-        navigation_compose_version = "2.7.6"
-        activity_compose_version = "1.8.2"
+        navigation_compose_version = "2.6.0"
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.3'

--- a/design-library-usage-sample/build.gradle
+++ b/design-library-usage-sample/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.what3words.design.library"
         minSdk 24
-        targetSdk 34
+        targetSdk 33
         versionCode 11
         versionName "1.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -61,11 +61,10 @@ android {
 
 dependencies {
     implementation project(":design-library")
-    implementation "androidx.compose.material3:material3:$material3_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+
     implementation "androidx.navigation:navigation-compose:$navigation_compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation "androidx.activity:activity-compose:$activity_compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
 }

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/MainActivity.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,7 +20,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.navigation.compose.rememberNavController
 import com.what3words.design.library.sample.ui.DesignLibraryApp
+import com.what3words.design.library.ui.theme.LocalSuccessColors
+import com.what3words.design.library.ui.theme.LocalSurfaceVariationsColors
+import com.what3words.design.library.ui.theme.LocalWarningColors
 import com.what3words.design.library.ui.theme.W3WTheme
+import com.what3words.design.library.ui.theme.darkSuccessColors
+import com.what3words.design.library.ui.theme.darkSurfaceVariationsColors
+import com.what3words.design.library.ui.theme.darkWarningColors
+import com.what3words.design.library.ui.theme.lightSuccessColors
+import com.what3words.design.library.ui.theme.lightSurfaceVariationsColors
+import com.what3words.design.library.ui.theme.lightWarningColors
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,14 +59,26 @@ class MainActivity : ComponentActivity() {
 
             when {
                 selectedTheme == MainActivityViewModel.Theme.Material && selectedColours == MainActivityViewModel.Colours.Day -> {
-                    MaterialTheme(colorScheme = lightColorScheme()) {
-                        mainScreen()
+                    CompositionLocalProvider(
+                        LocalSurfaceVariationsColors provides lightSurfaceVariationsColors,
+                        LocalSuccessColors provides lightSuccessColors,
+                        LocalWarningColors provides lightWarningColors
+                    ) {
+                        MaterialTheme(colorScheme = lightColorScheme()) {
+                            mainScreen()
+                        }
                     }
                 }
 
                 selectedTheme == MainActivityViewModel.Theme.Material && selectedColours == MainActivityViewModel.Colours.Night -> {
-                    MaterialTheme(colorScheme = darkColorScheme()) {
-                        mainScreen()
+                    CompositionLocalProvider(
+                        LocalSurfaceVariationsColors provides darkSurfaceVariationsColors,
+                        LocalSuccessColors provides darkSuccessColors,
+                        LocalWarningColors provides darkWarningColors
+                    ) {
+                        MaterialTheme(colorScheme = darkColorScheme()) {
+                            mainScreen()
+                        }
                     }
                 }
 

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/DesignLibraryApp.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/DesignLibraryApp.kt
@@ -3,7 +3,7 @@ package com.what3words.design.library.sample.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,6 +27,7 @@ import com.what3words.design.library.sample.ui.screens.IconButtonScreen
 import com.what3words.design.library.sample.ui.screens.ListItemScreen
 import com.what3words.design.library.sample.ui.screens.What3wordsAddressListItemScreen
 import com.what3words.design.library.sample.ui.screens.What3wordsAddressScreen
+import com.what3words.design.library.ui.theme.surfaceVariationsColors
 
 
 @ExperimentalMaterial3Api
@@ -58,7 +59,7 @@ fun DesignLibraryApp(
                             navController.popBackStack()
                         }) {
                             Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.Filled.ArrowBack,
                                 contentDescription = null
                             )
                         }
@@ -91,7 +92,7 @@ fun DesignLibraryApp(
     ) {
         NavHost(
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainer)
                 .padding(it),
             navController = navController,
             startDestination = NavScreen.Home.route

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ColorPaletteScreen.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ColorPaletteScreen.kt
@@ -200,97 +200,97 @@ fun ColorPaletteScreen(modifier: Modifier = Modifier) {
             )
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceDim)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceDim / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceBright)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceBright / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerLowest)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceContainerLowest / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceContainerLow / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainer)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceContainer / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceContainerHigh / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-        ) {
-            Text(
-                modifier = Modifier.padding(16.dp),
-                text = "surfaceContainerHighest / onSurface",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceDim)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceDim / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceBright)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceBright / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .padding(top = 8.dp)
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceContainerLowest / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceContainerLow / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceContainer)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceContainer / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceContainerHigh / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
+//
+//        Column(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+//        ) {
+//            Text(
+//                modifier = Modifier.padding(16.dp),
+//                text = "surfaceContainerHighest / onSurface",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.onSurface,
+//            )
+//        }
 
         Column(
             modifier = Modifier

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ColorPaletteScreen.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ColorPaletteScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.what3words.design.library.ui.theme.W3WTheme
 import com.what3words.design.library.ui.theme.successColors
+import com.what3words.design.library.ui.theme.surfaceVariationsColors
 import com.what3words.design.library.ui.theme.warningColors
 
 /**
@@ -200,97 +201,97 @@ fun ColorPaletteScreen(modifier: Modifier = Modifier) {
             )
         }
 
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceDim)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceDim / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceBright)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceBright / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .padding(top = 8.dp)
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceContainerLowest)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceContainerLowest / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceContainerLow / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceContainer)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceContainer / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceContainerHigh / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-//        ) {
-//            Text(
-//                modifier = Modifier.padding(16.dp),
-//                text = "surfaceContainerHighest / onSurface",
-//                style = MaterialTheme.typography.bodyMedium,
-//                color = MaterialTheme.colorScheme.onSurface,
-//            )
-//        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceDim)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceDim / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceBright)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceBright / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainerLowest)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceContainerLowest / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainerLow)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceContainerLow / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainer)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceContainer / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainerHigh)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceContainerHigh / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.surfaceVariationsColors.surfaceContainerHighest)
+        ) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "surfaceContainerHighest / onSurface",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
 
         Column(
             modifier = Modifier

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/HomeScreen.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/HomeScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledIconButton
@@ -151,7 +151,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier = Modifier) {
             },
             trailingContent = {
                 Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    Icons.Filled.KeyboardArrowRight,
                     contentDescription = "Localized description",
                 )
             }

--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ListItemScreen.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/ui/screens/ListItemScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -49,7 +49,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
             supportingContent = { Text("Supporting line text lorem ipsum dolor sit amet, consectetur.") },
             trailingContent = {
                 Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    Icons.Filled.KeyboardArrowRight,
                     contentDescription = "Localized description",
                 )
             }
@@ -67,7 +67,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
             },
             trailingContent = {
                 Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    Icons.Filled.KeyboardArrowRight,
                     contentDescription = "Localized description",
                 )
             }
@@ -78,7 +78,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
             headlineContent = { Text("List Item") },
             trailingContent = {
                 Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    Icons.Filled.KeyboardArrowRight,
                     contentDescription = "Localized description",
                 )
             }
@@ -101,7 +101,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
                     verticalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        Icons.Filled.KeyboardArrowRight,
                         contentDescription = "Localized description",
                     )
                 }
@@ -131,7 +131,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
                     verticalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        Icons.Filled.KeyboardArrowRight,
                         contentDescription = "Localized description",
                     )
                 }
@@ -154,7 +154,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
                     verticalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        Icons.Filled.KeyboardArrowRight,
                         contentDescription = "Localized description",
                     )
                 }
@@ -179,7 +179,7 @@ fun ListItemScreen(modifier: Modifier = Modifier) {
                         verticalArrangement = Arrangement.Center
                     ) {
                         Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            Icons.Filled.KeyboardArrowRight,
                             contentDescription = "Localized description",
                         )
                     }

--- a/design-library/build.gradle
+++ b/design-library/build.gradle
@@ -50,10 +50,9 @@ android {
 }
 
 dependencies {
-    implementation "androidx.compose.material3:material3-android:$material3_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
     implementation "androidx.constraintlayout:constraintlayout-compose:$constraint_layout_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-tooling-preview"
 }

--- a/design-library/src/main/java/com/what3words/design/library/ui/components/What3wordsAddressListItem.kt
+++ b/design-library/src/main/java/com/what3words/design/library/ui/components/What3wordsAddressListItem.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -38,6 +38,7 @@ import com.what3words.design.library.R
 import com.what3words.design.library.ui.models.DisplayUnits
 import com.what3words.design.library.ui.models.formatUnits
 import com.what3words.design.library.ui.theme.W3WTheme
+import com.what3words.design.library.ui.theme.surfaceVariationsColors
 import com.what3words.design.library.ui.theme.w3wTypography
 
 object What3wordsAddressListItemDefaults {
@@ -84,8 +85,8 @@ object What3wordsAddressListItemDefaults {
      */
     @Composable
     fun defaultColors(
-        background: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
-        backgroundHighlighted: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
+        background: Color = MaterialTheme.surfaceVariationsColors.surfaceContainerLowest,
+        backgroundHighlighted: Color = MaterialTheme.surfaceVariationsColors.surfaceContainerLowest,
         slashesColor: Color = MaterialTheme.colorScheme.primary,
         wordsTextColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
         iconColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
@@ -282,7 +283,7 @@ fun What3wordsAddressListItem(
             }
         }
         if (showDivider) {
-            HorizontalDivider(
+            Divider(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp),

--- a/design-library/src/main/java/com/what3words/design/library/ui/theme/Color.kt
+++ b/design-library/src/main/java/com/what3words/design/library/ui/theme/Color.kt
@@ -148,14 +148,7 @@ internal val w3wLightColors = lightColorScheme(
     inverseSurface = w3w_theme_light_inverseSurface,
     inversePrimary = w3w_theme_light_inversePrimary,
     outlineVariant = w3w_theme_light_outlineVariant,
-    scrim = w3w_theme_light_scrim,
-    surfaceBright = w3w_theme_light_surfaceBright,
-    surfaceDim = w3w_theme_light_surfaceDim,
-    surfaceContainer = w3w_theme_light_surfaceContainer,
-    surfaceContainerHigh = w3w_theme_light_surfaceContainerHigh,
-    surfaceContainerLow = w3w_theme_light_surfaceContainerLow,
-    surfaceContainerHighest = w3w_theme_light_surfaceContainerHighest,
-    surfaceContainerLowest = w3w_theme_light_surfaceContainerLowest
+    scrim = w3w_theme_light_scrim
 )
 
 /**
@@ -185,7 +178,35 @@ internal val w3wDarkColors = darkColorScheme(
     inverseSurface = w3w_theme_dark_inverseSurface,
     inversePrimary = w3w_theme_dark_inversePrimary,
     outlineVariant = w3w_theme_dark_outlineVariant,
-    scrim = w3w_theme_dark_scrim,
+    scrim = w3w_theme_dark_scrim
+)
+
+/**
+ * Data class representing custom surface variation colors, allowing for additional color customization. (to be deleted when updating material3 to 1.2.0)
+ */
+@Immutable
+data class SurfaceVariationsColors(
+    val surfaceBright: Color = Color.Unspecified,
+    val surfaceDim: Color = Color.Unspecified,
+    val surfaceContainer: Color = Color.Unspecified,
+    val surfaceContainerHigh: Color = Color.Unspecified,
+    val surfaceContainerLow: Color = Color.Unspecified,
+    val surfaceContainerHighest: Color = Color.Unspecified,
+    val surfaceContainerLowest: Color = Color.Unspecified,
+)
+
+// Success color assignments for light and dark themes.
+val lightSurfaceVariationsColors = SurfaceVariationsColors(
+    surfaceBright = w3w_theme_light_surfaceBright,
+    surfaceDim = w3w_theme_light_surfaceDim,
+    surfaceContainer = w3w_theme_light_surfaceContainer,
+    surfaceContainerHigh = w3w_theme_light_surfaceContainerHigh,
+    surfaceContainerLow = w3w_theme_light_surfaceContainerLow,
+    surfaceContainerHighest = w3w_theme_light_surfaceContainerHighest,
+    surfaceContainerLowest = w3w_theme_light_surfaceContainerLowest
+)
+
+val darkSurfaceVariationsColors = SurfaceVariationsColors(
     surfaceBright = w3w_theme_dark_surfaceBright,
     surfaceDim = w3w_theme_dark_surfaceDim,
     surfaceContainer = w3w_theme_dark_surfaceContainer,
@@ -250,10 +271,9 @@ val darkWarningColors = WarningColors(
 /**
  * Composition locals for custom success and warning colors.
  */
-val LocalDarkWarningColors = staticCompositionLocalOf { darkWarningColors }
-val LocalLightWarningColors = staticCompositionLocalOf { lightWarningColors }
-val LocalDarkSuccessColors = staticCompositionLocalOf { darkSuccessColors }
-val LocalLightSuccessColors = staticCompositionLocalOf { lightSuccessColors }
+val LocalWarningColors = staticCompositionLocalOf<WarningColors?> { null }
+val LocalSuccessColors = staticCompositionLocalOf<SuccessColors?> { null }
+val LocalSurfaceVariationsColors = staticCompositionLocalOf<SurfaceVariationsColors?> { null }
 
 /**
  * Extension properties on [MaterialTheme] to provide easy access to custom warning and success colors.
@@ -262,9 +282,14 @@ val LocalLightSuccessColors = staticCompositionLocalOf { lightSuccessColors }
 val MaterialTheme.warningColors: WarningColors
     @Composable
     @ReadOnlyComposable
-    get() = if (isSystemInDarkTheme()) LocalDarkWarningColors.current else LocalLightWarningColors.current
-
+    get() = LocalWarningColors.current ?: (if (isSystemInDarkTheme()) darkWarningColors else lightWarningColors)
 val MaterialTheme.successColors: SuccessColors
     @Composable
     @ReadOnlyComposable
-    get() = if (isSystemInDarkTheme()) LocalDarkSuccessColors.current else LocalLightSuccessColors.current
+    get() = LocalSuccessColors.current ?: (if (isSystemInDarkTheme()) darkSuccessColors else lightSuccessColors)
+
+//to be removed when updating material3 library
+val MaterialTheme.surfaceVariationsColors: SurfaceVariationsColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalSurfaceVariationsColors.current ?: (if (isSystemInDarkTheme()) darkSurfaceVariationsColors else lightSurfaceVariationsColors)

--- a/design-library/src/main/java/com/what3words/design/library/ui/theme/Theme.kt
+++ b/design-library/src/main/java/com/what3words/design/library/ui/theme/Theme.kt
@@ -29,6 +29,12 @@ fun W3WTheme(
         w3wDarkColors
     else w3wLightColors
 
+    val surfaceVariants = if (useDarkTheme) darkSurfaceVariationsColors else lightSurfaceVariationsColors
+
+    val successColors = if (useDarkTheme) darkSuccessColors else lightSuccessColors
+
+    val warningColors = if (useDarkTheme) darkWarningColors else lightWarningColors
+
     // Customize typography for the What3words theme.
     val w3wTypography = W3wTypography(
         headlineLargeProminent = MaterialTheme.typography.headlineLarge.copy(
@@ -49,7 +55,10 @@ fun W3WTheme(
 
     // Provide the What3words typography to the MaterialTheme.
     CompositionLocalProvider(
-        LocalW3wTypography provides w3wTypography
+        LocalW3wTypography provides w3wTypography,
+        LocalSurfaceVariationsColors provides surfaceVariants,
+        LocalSuccessColors provides successColors,
+        LocalWarningColors provides warningColors
     ) {
         MaterialTheme(
             colorScheme = colorScheme,


### PR DESCRIPTION
What changed:

- used compose BOM 2023.06.01 to be compatible with SDK 33
- Added LocalSurfaceVariationsColors and changed LocalSuccessColors and LocalWarningColors to either follow isSystemInDark mode if LocalComposition is not overridden by the Theme.
- I updated the sample app to reflect all the changes needed.