### PR TITLE
updated color scheme

### DIFF
--- a/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/MainActivity.kt
+++ b/design-library-usage-sample/src/main/java/com/what3words/design/library/sample/MainActivity.kt
@@ -23,10 +23,10 @@ import com.what3words.design.library.sample.ui.DesignLibraryApp
 import com.what3words.design.library.ui.theme.LocalSurfaceVariationsColors
 import com.what3words.design.library.ui.theme.LocalW3WColorScheme
 import com.what3words.design.library.ui.theme.W3WTheme
-import com.what3words.design.library.ui.theme.darkSurfaceVariationsColors
-import com.what3words.design.library.ui.theme.darkW3WColors
-import com.what3words.design.library.ui.theme.lightSurfaceVariationsColors
-import com.what3words.design.library.ui.theme.lightW3WColors
+import com.what3words.design.library.ui.theme.m3DarkSurfaceVariationsColors
+import com.what3words.design.library.ui.theme.m3DarkW3WSchemeColors
+import com.what3words.design.library.ui.theme.m3LightSurfaceVariationsColors
+import com.what3words.design.library.ui.theme.m3LightW3WSchemeColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
@@ -58,8 +58,8 @@ class MainActivity : ComponentActivity() {
             when {
                 selectedTheme == MainActivityViewModel.Theme.Material && selectedColours == MainActivityViewModel.Colours.Day -> {
                     CompositionLocalProvider(
-                        LocalSurfaceVariationsColors provides lightSurfaceVariationsColors,
-                        LocalW3WColorScheme provides lightW3WColors
+                        LocalSurfaceVariationsColors provides m3LightSurfaceVariationsColors,
+                        LocalW3WColorScheme provides m3LightW3WSchemeColors
                     ) {
                         MaterialTheme(colorScheme = lightColorScheme()) {
                             mainScreen()
@@ -69,8 +69,8 @@ class MainActivity : ComponentActivity() {
 
                 selectedTheme == MainActivityViewModel.Theme.Material && selectedColours == MainActivityViewModel.Colours.Night -> {
                     CompositionLocalProvider(
-                        LocalSurfaceVariationsColors provides darkSurfaceVariationsColors,
-                        LocalW3WColorScheme provides darkW3WColors
+                        LocalSurfaceVariationsColors provides m3DarkSurfaceVariationsColors,
+                        LocalW3WColorScheme provides m3DarkW3WSchemeColors
                     ) {
                         MaterialTheme(colorScheme = darkColorScheme()) {
                             mainScreen()

--- a/design-library/src/main/java/com/what3words/design/library/ui/theme/Color.kt
+++ b/design-library/src/main/java/com/what3words/design/library/ui/theme/Color.kt
@@ -16,180 +16,249 @@ import androidx.compose.ui.graphics.Color
  * These colors can be overridden in specific parts of the app using local composition.
  */
 
-// colors / primary
-val w3w_theme_light_primary = Color(0xFF187DB9)
-val w3w_theme_light_onPrimary = Color(0xFFFFFFFF)
-val w3w_theme_light_primaryContainer = Color(0xFFDBEFFA)
-val w3w_theme_light_onPrimaryContainer = Color(0xFF001D31)
-val w3w_theme_light_inversePrimary = Color(0xFFC2E1EB)
-
-val w3w_theme_dark_primary = Color(0xFF60B2F2)
-val w3w_theme_dark_onPrimary = Color(0xFF0A3049)
-val w3w_theme_dark_primaryContainer = Color(0xFF005379)
-val w3w_theme_dark_onPrimaryContainer = Color(0xFFDBEFFA)
-val w3w_theme_dark_inversePrimary = Color(0xFF006397)
-
-// colors / secondary
-val w3w_theme_light_secondary = Color(0xFF006397)
-val w3w_theme_light_onSecondary = Color(0xFFFFFFFF)
-val w3w_theme_light_secondaryContainer = Color(0xFFC2E1EB)
-val w3w_theme_light_onSecondaryContainer = Color(0xFF001D31)
-
-val w3w_theme_dark_secondary = Color(0xFFC2E1EB)
-val w3w_theme_dark_onSecondary = Color(0xFF0A3049)
-val w3w_theme_dark_secondaryContainer = Color(0xFF005379)
-val w3w_theme_dark_onSecondaryContainer = Color(0xFFFCFCFF)
-
-// colors / brand
-val w3w_theme_light_brand = Color(0xFFE11F26)
-val w3w_theme_light_onBrand = Color(0xFFFFFFFF)
-val w3w_theme_light_brandContainer = Color(0xFFFFEDEA)
-val w3w_theme_light_onBrandContainer = Color(0xFF930002)
-
-val w3w_theme_dark_brand = Color(0xFFE11F26)
-val w3w_theme_dark_onBrand = Color(0xFF410000)
-val w3w_theme_dark_brandContainer = Color(0xFF930002)
-val w3w_theme_dark_onBrandContainer = Color(0xFFFFCAC2)
-
-// states / error
-val w3w_theme_light_error = Color(0xFFF26C50)
-val w3w_theme_light_onError = Color(0xFFFFFFFF)
-val w3w_theme_light_errorContainer = Color(0xFFFFEDE9)
-val w3w_theme_light_onErrorContainer = Color(0xFF3E0500)
-
-val w3w_theme_dark_error = Color(0xFFFFB4A4)
-val w3w_theme_dark_onError = Color(0xFF3E0500)
-val w3w_theme_dark_errorContainer = Color(0xFFF26C50)
-val w3w_theme_dark_onErrorContainer = Color(0xFF640D00)
-
-// states / warning
-val w3w_theme_light_warning = Color(0xFFC7AA00)
-val w3w_theme_light_onWarning = Color(0xFFFFFFFF)
-val w3w_theme_light_warningContainer = Color(0xFFFFFBFF)
-val w3w_theme_light_onWarningContainer = Color(0xFF6F5D00)
-
-val w3w_theme_dark_warning = Color(0xFFFFEC8A)
-val w3w_theme_dark_onWarning = Color(0xFF6F5D00)
-val w3w_theme_dark_warningContainer = Color(0xFFC7AA00)
-val w3w_theme_dark_onWarningContainer = Color(0xFFFFF4B2)
-
-// states / success.
-val w3w_theme_light_success = Color(0xFF53C18A)
-val w3w_theme_light_onSuccess = Color(0xFFFFFFFF)
-val w3w_theme_light_successContainer = Color(0xFFF5FFF5)
-val w3w_theme_light_onSuccessContainer = Color(0xFF003822)
-
-val w3w_theme_dark_success = Color(0xFF6ECB9C)
-val w3w_theme_dark_onSuccess = Color(0xFF003822)
-val w3w_theme_dark_successContainer = Color(0xFF006C45)
-val w3w_theme_dark_onSuccessContainer = Color(0xFF8BF8BD)
-
-// surfaces
-val w3w_theme_light_surfaceDim = Color(0xFFD9DADD)
-val w3w_theme_light_surface = Color(0xFFF9F9FC)
-val w3w_theme_light_surfaceBright = Color(0xFFFCFCFF)
-val w3w_theme_light_surfaceVariant = Color(0xFFDFE3E8)
-val w3w_theme_light_surfaceContainerLowest = Color(0xFFFFFFFF)
-val w3w_theme_light_surfaceContainerLow = Color(0xFFF3F3F6)
-val w3w_theme_light_surfaceContainer = Color(0xFFEDEEF0)
-val w3w_theme_light_surfaceContainerHigh = Color(0xFFE7E8EB)
-val w3w_theme_light_surfaceContainerHighest = Color(0xFFE2E2E5)
-val w3w_theme_light_onSurface = Color(0xFF1A1C1E)
-val w3w_theme_light_onSurfaceVariant = Color(0xFF43474B)
-val w3w_theme_light_inverseSurface = Color(0xFF2E3133)
-val w3w_theme_light_inverseOnSurface = Color(0xFFF0F0F3)
-
-val w3w_theme_dark_surfaceDim = Color(0xFF111416)
-val w3w_theme_dark_surface = Color(0xFF111416)
-val w3w_theme_dark_surfaceBright = Color(0xFF37393C)
-val w3w_theme_dark_surfaceVariant = Color(0xFF43474B)
-val w3w_theme_dark_surfaceContainerLowest = Color(0xFF0C0E11)
-val w3w_theme_dark_surfaceContainerLow = Color(0xFF1A1C1E)
-val w3w_theme_dark_surfaceContainer = Color(0xFF1E2022)
-val w3w_theme_dark_surfaceContainerHigh = Color(0xFF282A2D)
-val w3w_theme_dark_surfaceContainerHighest = Color(0xFF333537)
-val w3w_theme_dark_onSurface = Color(0xFFE2E2E5)
-val w3w_theme_dark_onSurfaceVariant = Color(0xFFC3C7CC)
-val w3w_theme_dark_inverseSurface = Color(0xFFE2E2E5)
-val w3w_theme_dark_inverseOnSurface = Color(0xFF2E3133)
-
-// outline
-val w3w_theme_light_outline = Color(0xFF73777C)
-val w3w_theme_light_outlineVariant = Color(0xFFC3C7CC)
-
-val w3w_theme_dark_outline = Color(0xFF8D9196)
-val w3w_theme_dark_outlineVariant = Color(0xFF43474B)
-
-// backgrounds
-val w3w_theme_light_background = Color(0xFFFFFBFF)
-val w3w_theme_light_onBackground = Color(0xFF1A1C1E)
-
-val w3w_theme_dark_background = Color(0xFF1A1C1E)
-val w3w_theme_dark_onBackground = Color(0xFFE2E2E5)
-
-//scrim
-val w3w_theme_light_scrim = Color(0xFF000000)
-
-val w3w_theme_dark_scrim = Color(0xFF000000)
+val colors_primary_core_primary_light_m3 = Color(0xff6750a4)
+val colors_primary_core_primary_dark_m3 = Color(0xffcfbcff)
+val colors_primary_core_primary_light_w3w = Color(0xff187db9)
+val colors_primary_core_primary_dark_w3w = Color(0xff8dd4eb)
+val colors_primary_core_on_primary_light_m3 = Color(0xffffffff)
+val colors_primary_core_on_primary_dark_m3 = Color(0xff381e72)
+val colors_primary_core_on_primary_light_w3w = Color(0xffffffff)
+val colors_primary_core_on_primary_dark_w3w = Color(0xff0a3049)
+val colors_primary_core_primary_container_light_m3 = Color(0xffe9ddff)
+val colors_primary_core_primary_container_dark_m3 = Color(0xff4f378a)
+val colors_primary_core_primary_container_light_w3w = Color(0xffdbeffa)
+val colors_primary_core_primary_container_dark_w3w = Color(0xff005379)
+val colors_primary_core_on_primary_container_light_m3 = Color(0xff22005d)
+val colors_primary_core_on_primary_container_dark_m3 = Color(0xffe9ddff)
+val colors_primary_core_on_primary_container_light_w3w = Color(0xff0a3049)
+val colors_primary_core_on_primary_container_dark_w3w = Color(0xffdbeffa)
+val colors_primary_core_inverse_primary_light_m3 = Color(0xffcfbcff)
+val colors_primary_core_inverse_primary_dark_m3 = Color(0xff6750a4)
+val colors_primary_core_inverse_primary_light_w3w = Color(0xffc2e1eb)
+val colors_primary_core_inverse_primary_dark_w3w = Color(0xff006397)
+val colors_secondary_core_secondary_light_m3 = Color(0xff625b71)
+val colors_secondary_core_secondary_dark_m3 = Color(0xffcbc2db)
+val colors_secondary_core_secondary_light_w3w = Color(0xff006397)
+val colors_secondary_core_secondary_dark_w3w = Color(0xff187db9)
+val colors_brand_brand_light_m3 = Color(0xff53c18a)
+val colors_brand_brand_dark_m3 = Color(0xff53c18a)
+val colors_brand_brand_light_w3w = Color(0xffe11f26)
+val colors_brand_brand_dark_w3w = Color(0xffe11f26)
+val colors_brand_on_brand_light_m3 = Color(0xffffffff)
+val colors_brand_on_brand_dark_m3 = Color(0xff003822)
+val colors_brand_on_brand_light_w3w = Color(0xfffffbff)
+val colors_brand_on_brand_dark_w3w = Color(0xfffffbff)
+val colors_brand_brand_container_light_m3 = Color(0xff8bf8bd)
+val colors_brand_brand_container_dark_m3 = Color(0xff006c45)
+val colors_brand_brand_container_light_w3w = Color(0xffffedea)
+val colors_brand_brand_container_dark_w3w = Color(0xff930002)
+val colors_brand_on_brand_container_light_m3 = Color(0xff002112)
+val colors_brand_on_brand_container_dark_m3 = Color(0xff8bf8bd)
+val colors_brand_on_brand_container_light_w3w = Color(0xff930002)
+val colors_brand_on_brand_container_dark_w3w = Color(0xffffcac2)
+val colors_secondary_core_on_secondary_light_m3 = Color(0xffffffff)
+val colors_secondary_core_on_secondary_dark_m3 = Color(0xff332d41)
+val colors_secondary_core_on_secondary_light_w3w = Color(0xffffffff)
+val colors_secondary_core_on_secondary_dark_w3w = Color(0xffdbeffa)
+val colors_secondary_core_secondary_container_light_m3 = Color(0xffe8def8)
+val colors_secondary_core_secondary_container_dark_m3 = Color(0xff4a4458)
+val colors_secondary_core_secondary_container_light_w3w = Color(0xffc2e1eb)
+val colors_secondary_core_secondary_container_dark_w3w = Color(0xff005379)
+val colors_secondary_core_on_secondary_container_light_m3 = Color(0xff1e192b)
+val colors_secondary_core_on_secondary_container_dark_m3 = Color(0xffe8def8)
+val colors_secondary_core_on_secondary_container_light_w3w = Color(0xff0a3049)
+val colors_secondary_core_on_secondary_container_dark_w3w = Color(0xfffcfcff)
+val states_error_error_light_m3 = Color(0xff93000a)
+val states_error_error_dark_m3 = Color(0xffffdad6)
+val states_error_error_light_w3w = Color(0xfff26c50)
+val states_error_error_dark_w3w = Color(0xffffb4a4)
+val states_warning_warning_light_m3 = Color(0xffc7aa00)
+val states_warning_warning_dark_m3 = Color(0xffffec8a)
+val states_warning_warning_light_w3w = Color(0xffc7aa00)
+val states_warning_warning_dark_w3w = Color(0xffffec8a)
+val states_success_success_light_m3 = Color(0xff53c18a)
+val states_success_success_dark_m3 = Color(0xff6ecb9c)
+val states_success_success_light_w3w = Color(0xff53c18a)
+val states_success_success_dark_w3w = Color(0xff6ecb9c)
+val states_success_on_success_light_m3 = Color(0xffffffff)
+val states_success_on_success_dark_m3 = Color(0xff003822)
+val states_success_on_success_light_w3w = Color(0xffffffff)
+val states_success_on_success_dark_w3w = Color(0xff003822)
+val states_success_success_container_light_m3 = Color(0xfff5fff5)
+val states_success_success_container_dark_m3 = Color(0xff006c45)
+val states_success_success_container_light_w3w = Color(0xfff5fff5)
+val states_success_success_container_dark_w3w = Color(0xff006c45)
+val states_success_on_success_container_light_m3 = Color(0xff003822)
+val states_success_on_success_container_dark_m3 = Color(0xffa2dfbd)
+val states_success_on_success_container_light_w3w = Color(0xff003822)
+val states_success_on_success_container_dark_w3w = Color(0xffa2dfbd)
+val states_warning_on_warning_light_m3 = Color(0xffffffff)
+val states_warning_on_warning_dark_m3 = Color(0xff6f5d00)
+val states_warning_on_warning_light_w3w = Color(0xffffffff)
+val states_warning_on_warning_dark_w3w = Color(0xff2f2500)
+val states_warning_warning_container_light_m3 = Color(0xfffffbff)
+val states_warning_warning_container_dark_m3 = Color(0xffc7aa00)
+val states_warning_warning_container_light_w3w = Color(0xfffffbff)
+val states_warning_warning_container_dark_w3w = Color(0xffc7aa00)
+val states_warning_on_warning_container_light_m3 = Color(0xff6f5d00)
+val states_warning_on_warning_container_dark_m3 = Color(0xfffff4b2)
+val states_warning_on_warning_container_light_w3w = Color(0xff2f2500)
+val states_warning_on_warning_container_dark_w3w = Color(0xfffff4b2)
+val states_error_on_error_light_m3 = Color(0xffffffff)
+val states_error_on_error_dark_m3 = Color(0xff410002)
+val states_error_on_error_light_w3w = Color(0xffffffff)
+val states_error_on_error_dark_w3w = Color(0xff3e0500)
+val states_error_error_container_light_m3 = Color(0xffffedea)
+val states_error_error_container_dark_m3 = Color(0xff93000a)
+val states_error_error_container_light_w3w = Color(0xffffede9)
+val states_error_error_container_dark_w3w = Color(0xfff26c50)
+val states_error_on_error_container_light_m3 = Color(0xff93000a)
+val states_error_on_error_container_dark_m3 = Color(0xffffdad6)
+val states_error_on_error_container_light_w3w = Color(0xff3e0500)
+val states_error_on_error_container_dark_w3w = Color(0xff640d00)
+val surfaces_surface_dim_light_m3 = Color(0xffded8e1)
+val surfaces_surface_dim_dark_m3 = Color(0xff141218)
+val surfaces_surface_dim_light_w3w = Color(0xffd9dadd)
+val surfaces_surface_dim_dark_w3w = Color(0xff111416)
+val surfaces_surface_light_m3 = Color(0xfffffbfe)
+val surfaces_surface_dark_m3 = Color(0xff141218)
+val surfaces_surface_light_w3w = Color(0xfff9f9fc)
+val surfaces_surface_dark_w3w = Color(0xff111416)
+val surfaces_surface_bright_light_m3 = Color(0xfffffbff)
+val surfaces_surface_bright_dark_m3 = Color(0xff3b383e)
+val surfaces_surface_bright_light_w3w = Color(0xfffcfcff)
+val surfaces_surface_bright_dark_w3w = Color(0xff37393c)
+val surfaces_surface_variant_light_m3 = Color(0xffe7e0ec)
+val surfaces_surface_variant_dark_m3 = Color(0xff49454f)
+val surfaces_surface_variant_light_w3w = Color(0xffdfe3e8)
+val surfaces_surface_variant_dark_w3w = Color(0xff43474b)
+val surfaces_surface_container_lowest_light_m3 = Color(0xffffffff)
+val surfaces_surface_container_lowest_dark_m3 = Color(0xff0f0d13)
+val surfaces_surface_container_lowest_light_w3w = Color(0xffffffff)
+val surfaces_surface_container_lowest_dark_w3w = Color(0xff0c0e11)
+val surfaces_surface_container_low_light_m3 = Color(0xfff7f2fa)
+val surfaces_surface_container_low_dark_m3 = Color(0xff1d1b20)
+val surfaces_surface_container_low_light_w3w = Color(0xfff3f3f6)
+val surfaces_surface_container_low_dark_w3w = Color(0xff1a1c1e)
+val surfaces_surface_container_light_m3 = Color(0xfff3edf7)
+val surfaces_surface_container_dark_m3 = Color(0xff211f26)
+val surfaces_surface_container_light_w3w = Color(0xffedeef0)
+val surfaces_surface_container_dark_w3w = Color(0xff1e2022)
+val surfaces_surface_container_high_light_m3 = Color(0xffece6f0)
+val surfaces_surface_container_high_dark_m3 = Color(0xff2b2930)
+val surfaces_surface_container_high_light_w3w = Color(0xffe7e8eb)
+val surfaces_surface_container_high_dark_w3w = Color(0xff282a2d)
+val surfaces_surface_container_highest_light_m3 = Color(0xffe6e0e9)
+val surfaces_surface_container_highest_dark_m3 = Color(0xff36343b)
+val surfaces_surface_container_highest_light_w3w = Color(0xffe2e2e5)
+val surfaces_surface_container_highest_dark_w3w = Color(0xff333537)
+val surfaces_on_surface_light_m3 = Color(0xff1d1b20)
+val surfaces_on_surface_dark_m3 = Color(0xffe6e0e9)
+val surfaces_on_surface_light_w3w = Color(0xff1a1c1e)
+val surfaces_on_surface_dark_w3w = Color(0xffffffff)
+val surfaces_on_surface_variant_light_m3 = Color(0xff49454f)
+val surfaces_on_surface_variant_dark_m3 = Color(0xffcac4d0)
+val surfaces_on_surface_variant_light_w3w = Color(0xff43474b)
+val surfaces_on_surface_variant_dark_w3w = Color(0xffc3c7cc)
+val surfaces_on_surface_white_light_m3 = Color(0xfffffbfe)
+val surfaces_on_surface_white_dark_m3 = Color(0xfffffbfe)
+val surfaces_on_surface_white_light_w3w = Color(0xfff9f9fc)
+val surfaces_on_surface_white_dark_w3w = Color(0xfffffbfe)
+val surfaces_on_surface_black_light_m3 = Color(0xff141218)
+val surfaces_on_surface_black_dark_m3 = Color(0xff141218)
+val surfaces_on_surface_black_light_w3w = Color(0xff111416)
+val surfaces_on_surface_black_dark_w3w = Color(0xff111416)
+val surfaces_inverse_surface_light_m3 = Color(0xff141218)
+val surfaces_inverse_surface_dark_m3 = Color(0xfffffbfe)
+val surfaces_inverse_surface_light_w3w = Color(0xff111416)
+val surfaces_inverse_surface_dark_w3w = Color(0xfff9f9fc)
+val surfaces_inverse_on_surface_light_m3 = Color(0xffe6e0e9)
+val surfaces_inverse_on_surface_dark_m3 = Color(0xff1d1b20)
+val surfaces_inverse_on_surface_light_w3w = Color(0xffffffff)
+val surfaces_inverse_on_surface_dark_w3w = Color(0xff1a1c1e)
+val outlines_outline_light_m3 = Color(0xff79747e)
+val outlines_outline_dark_m3 = Color(0xff938f99)
+val outlines_outline_light_w3w = Color(0xff73777c)
+val outlines_outline_dark_w3w = Color(0xff8d9196)
+val outlines_outline_variant_light_m3 = Color(0xffcac4d0)
+val outlines_outline_variant_dark_m3 = Color(0xff49454f)
+val outlines_outline_variant_light_w3w = Color(0xffc3c7cc)
+val outlines_outline_variant_dark_w3w = Color(0xff43474b)
+val backgrounds_background_light_m3 = Color(0xfffffbfe)
+val backgrounds_background_dark_m3 = Color(0xff1d1b20)
+val backgrounds_background_light_w3w = Color(0xfffffbff)
+val backgrounds_background_dark_w3w = Color(0xff000000)
+val backgrounds_on_background_light_m3 = Color(0xff1d1b20)
+val backgrounds_on_background_dark_m3 = Color(0xffe6e0e9)
+val backgrounds_on_background_light_w3w = Color(0xff1a1c1e)
+val backgrounds_on_background_dark_w3w = Color(0xffe2e2e5)
+val scrim_scrim_light_m3 = Color(0xff000000)
+val scrim_scrim_dark_m3 = Color(0xff000000)
+val scrim_scrim_light_w3w = Color(0xff000000)
+val scrim_scrim_dark_w3w = Color(0xff000000)
+val shadow_shadow_light_m3 = Color(0xff000000)
+val shadow_shadow_dark_m3 = Color(0xff000000)
+val shadow_shadow_light_w3w = Color(0xff000000)
+val shadow_shadow_dark_w3w = Color(0xff000000)
 
 /**
  * Defines a custom color scheme for What3words using the defined colors for light themes.
  */
 internal val w3wLightColors = lightColorScheme(
-    primary = w3w_theme_light_primary,
-    onPrimary = w3w_theme_light_onPrimary,
-    primaryContainer = w3w_theme_light_primaryContainer,
-    onPrimaryContainer = w3w_theme_light_onPrimaryContainer,
-    secondary = w3w_theme_light_secondary,
-    onSecondary = w3w_theme_light_onSecondary,
-    secondaryContainer = w3w_theme_light_secondaryContainer,
-    onSecondaryContainer = w3w_theme_light_onSecondaryContainer,
-    error = w3w_theme_light_error,
-    errorContainer = w3w_theme_light_errorContainer,
-    onError = w3w_theme_light_onError,
-    onErrorContainer = w3w_theme_light_onErrorContainer,
-    background = w3w_theme_light_background,
-    onBackground = w3w_theme_light_onBackground,
-    surface = w3w_theme_light_surface,
-    onSurface = w3w_theme_light_onSurface,
-    surfaceVariant = w3w_theme_light_surfaceVariant,
-    onSurfaceVariant = w3w_theme_light_onSurfaceVariant,
-    outline = w3w_theme_light_outline,
-    inverseOnSurface = w3w_theme_light_inverseOnSurface,
-    inverseSurface = w3w_theme_light_inverseSurface,
-    inversePrimary = w3w_theme_light_inversePrimary,
-    outlineVariant = w3w_theme_light_outlineVariant,
-    scrim = w3w_theme_light_scrim
+    primary = colors_primary_core_primary_light_w3w,
+    onPrimary = colors_primary_core_on_primary_light_w3w,
+    primaryContainer = colors_primary_core_primary_container_light_w3w,
+    onPrimaryContainer = colors_primary_core_on_primary_container_light_w3w,
+    secondary = colors_secondary_core_secondary_light_w3w,
+    onSecondary = colors_secondary_core_on_secondary_light_w3w,
+    secondaryContainer = colors_secondary_core_secondary_container_light_w3w,
+    onSecondaryContainer = colors_secondary_core_on_secondary_container_light_w3w,
+    error = states_error_error_light_w3w,
+    errorContainer = states_error_error_container_light_w3w,
+    onError = states_error_on_error_light_w3w,
+    onErrorContainer = states_error_on_error_container_light_w3w,
+    background = backgrounds_background_light_w3w,
+    onBackground = backgrounds_on_background_light_w3w,
+    surface = surfaces_surface_light_w3w,
+    onSurface = surfaces_on_surface_light_w3w,
+    surfaceVariant = surfaces_surface_variant_light_w3w,
+    onSurfaceVariant = surfaces_on_surface_variant_light_w3w,
+    outline = outlines_outline_light_w3w,
+    inverseOnSurface = surfaces_inverse_on_surface_light_w3w,
+    inverseSurface = surfaces_inverse_surface_light_w3w,
+    inversePrimary = colors_primary_core_inverse_primary_light_w3w,
+    outlineVariant = outlines_outline_variant_light_w3w,
+    scrim = scrim_scrim_light_w3w
 )
 
 /**
  * Defines a custom color scheme for What3words using the defined colors for dark themes.
  */
 internal val w3wDarkColors = darkColorScheme(
-    primary = w3w_theme_dark_primary,
-    onPrimary = w3w_theme_dark_onPrimary,
-    primaryContainer = w3w_theme_dark_primaryContainer,
-    onPrimaryContainer = w3w_theme_dark_onPrimaryContainer,
-    secondary = w3w_theme_dark_secondary,
-    onSecondary = w3w_theme_dark_onSecondary,
-    secondaryContainer = w3w_theme_dark_secondaryContainer,
-    onSecondaryContainer = w3w_theme_dark_onSecondaryContainer,
-    error = w3w_theme_dark_error,
-    errorContainer = w3w_theme_dark_errorContainer,
-    onError = w3w_theme_dark_onError,
-    onErrorContainer = w3w_theme_dark_onErrorContainer,
-    background = w3w_theme_dark_background,
-    onBackground = w3w_theme_dark_onBackground,
-    surface = w3w_theme_dark_surface,
-    onSurface = w3w_theme_dark_onSurface,
-    surfaceVariant = w3w_theme_dark_surfaceVariant,
-    onSurfaceVariant = w3w_theme_dark_onSurfaceVariant,
-    outline = w3w_theme_dark_outline,
-    inverseOnSurface = w3w_theme_dark_inverseOnSurface,
-    inverseSurface = w3w_theme_dark_inverseSurface,
-    inversePrimary = w3w_theme_dark_inversePrimary,
-    outlineVariant = w3w_theme_dark_outlineVariant,
-    scrim = w3w_theme_dark_scrim
+    primary = colors_primary_core_primary_dark_w3w,
+    onPrimary = colors_primary_core_on_primary_dark_w3w,
+    primaryContainer = colors_primary_core_primary_container_dark_w3w,
+    onPrimaryContainer = colors_primary_core_on_primary_container_dark_w3w,
+    secondary = colors_secondary_core_secondary_dark_w3w,
+    onSecondary = colors_secondary_core_on_secondary_dark_w3w,
+    secondaryContainer = colors_secondary_core_secondary_container_dark_w3w,
+    onSecondaryContainer = colors_secondary_core_on_secondary_container_dark_w3w,
+    error = states_error_error_dark_w3w,
+    errorContainer = states_error_error_container_dark_w3w,
+    onError = states_error_on_error_dark_w3w,
+    onErrorContainer = states_error_on_error_container_dark_w3w,
+    background = backgrounds_background_dark_w3w,
+    onBackground = backgrounds_on_background_dark_w3w,
+    surface = surfaces_surface_dark_w3w,
+    onSurface = surfaces_on_surface_dark_w3w,
+    surfaceVariant = surfaces_surface_variant_dark_w3w,
+    onSurfaceVariant = surfaces_on_surface_variant_dark_w3w,
+    outline = outlines_outline_dark_w3w,
+    inverseOnSurface = surfaces_inverse_on_surface_dark_w3w,
+    inverseSurface = surfaces_inverse_surface_dark_w3w,
+    inversePrimary = colors_primary_core_inverse_primary_dark_w3w,
+    outlineVariant = outlines_outline_variant_dark_w3w,
+    scrim = scrim_scrim_dark_w3w
 )
 
 /**
@@ -207,24 +276,45 @@ data class SurfaceVariationsColors(
 )
 
 // Success color assignments for light and dark themes.
-val lightSurfaceVariationsColors = SurfaceVariationsColors(
-    surfaceBright = w3w_theme_light_surfaceBright,
-    surfaceDim = w3w_theme_light_surfaceDim,
-    surfaceContainer = w3w_theme_light_surfaceContainer,
-    surfaceContainerHigh = w3w_theme_light_surfaceContainerHigh,
-    surfaceContainerLow = w3w_theme_light_surfaceContainerLow,
-    surfaceContainerHighest = w3w_theme_light_surfaceContainerHighest,
-    surfaceContainerLowest = w3w_theme_light_surfaceContainerLowest
+val w3wLightSurfaceVariationsColors = SurfaceVariationsColors(
+    surfaceBright = surfaces_surface_bright_light_w3w,
+    surfaceDim = surfaces_surface_dim_light_w3w,
+    surfaceContainer = surfaces_surface_container_light_w3w,
+    surfaceContainerHigh = surfaces_surface_container_high_light_w3w,
+    surfaceContainerLow = surfaces_surface_container_low_light_w3w,
+    surfaceContainerHighest = surfaces_surface_container_highest_light_w3w,
+    surfaceContainerLowest = surfaces_surface_container_lowest_light_w3w
 )
 
-val darkSurfaceVariationsColors = SurfaceVariationsColors(
-    surfaceBright = w3w_theme_dark_surfaceBright,
-    surfaceDim = w3w_theme_dark_surfaceDim,
-    surfaceContainer = w3w_theme_dark_surfaceContainer,
-    surfaceContainerHigh = w3w_theme_dark_surfaceContainerHigh,
-    surfaceContainerLow = w3w_theme_dark_surfaceContainerLow,
-    surfaceContainerHighest = w3w_theme_dark_surfaceContainerHighest,
-    surfaceContainerLowest = w3w_theme_dark_surfaceContainerLowest
+val w3wDarkSurfaceVariationsColors = SurfaceVariationsColors(
+    surfaceBright = surfaces_surface_bright_dark_w3w,
+    surfaceDim = surfaces_surface_dim_dark_w3w,
+    surfaceContainer = surfaces_surface_container_dark_w3w,
+    surfaceContainerHigh = surfaces_surface_container_high_dark_w3w,
+    surfaceContainerLow = surfaces_surface_container_low_dark_w3w,
+    surfaceContainerHighest = surfaces_surface_container_highest_dark_w3w,
+    surfaceContainerLowest = surfaces_surface_container_lowest_dark_w3w
+)
+
+// Success color assignments for light and dark themes.
+val m3LightSurfaceVariationsColors = SurfaceVariationsColors(
+    surfaceBright = surfaces_surface_bright_light_m3,
+    surfaceDim = surfaces_surface_dim_light_m3,
+    surfaceContainer = surfaces_surface_container_light_m3,
+    surfaceContainerHigh = surfaces_surface_container_high_light_m3,
+    surfaceContainerLow = surfaces_surface_container_low_light_m3,
+    surfaceContainerHighest = surfaces_surface_container_highest_light_m3,
+    surfaceContainerLowest = surfaces_surface_container_lowest_light_m3
+)
+
+val m3DarkSurfaceVariationsColors = SurfaceVariationsColors(
+    surfaceBright = surfaces_surface_bright_dark_m3,
+    surfaceDim = surfaces_surface_dim_dark_m3,
+    surfaceContainer = surfaces_surface_container_dark_m3,
+    surfaceContainerHigh = surfaces_surface_container_high_dark_m3,
+    surfaceContainerLow = surfaces_surface_container_low_dark_m3,
+    surfaceContainerHighest = surfaces_surface_container_highest_dark_m3,
+    surfaceContainerLowest = surfaces_surface_container_lowest_dark_m3
 )
 
 /**
@@ -247,35 +337,66 @@ data class W3WColorScheme(
 )
 
 // W3W proprietary color assignments for light and dark themes.
-val lightW3WColors = W3WColorScheme(
-    warning = w3w_theme_light_warning,
-    onWarning = w3w_theme_light_onWarning,
-    warningContainer = w3w_theme_light_warningContainer,
-    onWarningContainer = w3w_theme_light_onWarningContainer,
-    success = w3w_theme_light_success,
-    onSuccess = w3w_theme_light_onSuccess,
-    successContainer = w3w_theme_light_successContainer,
-    onSuccessContainer = w3w_theme_light_onSuccessContainer,
-    brand = w3w_theme_light_brand,
-    onBrand = w3w_theme_light_onBrand,
-    brandContainer = w3w_theme_light_brandContainer,
-    onBrandContainer = w3w_theme_light_onBrandContainer
+val w3wLightW3WSchemeColors = W3WColorScheme(
+    warning = states_warning_warning_light_w3w,
+    onWarning = states_warning_on_warning_light_w3w,
+    warningContainer = states_warning_warning_container_light_w3w,
+    onWarningContainer = states_warning_on_warning_container_light_w3w,
+    success = states_success_success_light_w3w,
+    onSuccess = states_success_on_success_light_w3w,
+    successContainer = states_success_success_container_light_w3w,
+    onSuccessContainer = states_success_on_success_container_light_w3w,
+    brand = colors_brand_brand_light_w3w,
+    onBrand = colors_brand_on_brand_light_w3w,
+    brandContainer = colors_brand_brand_container_light_w3w,
+    onBrandContainer = colors_brand_on_brand_container_light_w3w
 )
 
-val darkW3WColors = W3WColorScheme(
-    warning = w3w_theme_dark_warning,
-    onWarning = w3w_theme_dark_onWarning,
-    warningContainer = w3w_theme_dark_warningContainer,
-    onWarningContainer = w3w_theme_dark_onWarningContainer,
-    success = w3w_theme_dark_success,
-    onSuccess = w3w_theme_dark_onSuccess,
-    successContainer = w3w_theme_dark_successContainer,
-    onSuccessContainer = w3w_theme_dark_onSuccessContainer,
-    brand = w3w_theme_dark_brand,
-    onBrand = w3w_theme_dark_onBrand,
-    brandContainer = w3w_theme_dark_brandContainer,
-    onBrandContainer = w3w_theme_dark_onBrandContainer
+val w3wDarkW3WSchemeColors = W3WColorScheme(
+    warning = states_warning_warning_dark_w3w,
+    onWarning = states_warning_on_warning_dark_w3w,
+    warningContainer = states_warning_warning_container_dark_w3w,
+    onWarningContainer = states_warning_on_warning_container_dark_w3w,
+    success = states_success_success_dark_w3w,
+    onSuccess = states_success_on_success_dark_w3w,
+    successContainer = states_success_success_container_dark_w3w,
+    onSuccessContainer = states_success_on_success_container_dark_w3w,
+    brand = colors_brand_brand_dark_w3w,
+    onBrand = colors_brand_on_brand_dark_w3w,
+    brandContainer = colors_brand_brand_container_dark_w3w,
+    onBrandContainer = colors_brand_on_brand_container_dark_w3w
 )
+
+val m3LightW3WSchemeColors = W3WColorScheme(
+    warning = states_warning_warning_light_m3,
+    onWarning = states_warning_on_warning_light_m3,
+    warningContainer = states_warning_warning_container_light_m3,
+    onWarningContainer = states_warning_on_warning_container_light_m3,
+    success = states_success_success_light_m3,
+    onSuccess = states_success_on_success_light_m3,
+    successContainer = states_success_success_container_light_m3,
+    onSuccessContainer = states_success_on_success_container_light_m3,
+    brand = colors_brand_brand_light_m3,
+    onBrand = colors_brand_on_brand_light_m3,
+    brandContainer = colors_brand_brand_container_light_m3,
+    onBrandContainer = colors_brand_on_brand_container_light_m3
+)
+
+val m3DarkW3WSchemeColors = W3WColorScheme(
+    warning = states_warning_warning_dark_m3,
+    onWarning = states_warning_on_warning_dark_m3,
+    warningContainer = states_warning_warning_container_dark_m3,
+    onWarningContainer = states_warning_on_warning_container_dark_m3,
+    success = states_success_success_dark_m3,
+    onSuccess = states_success_on_success_dark_m3,
+    successContainer = states_success_success_container_dark_m3,
+    onSuccessContainer = states_success_on_success_container_dark_m3,
+    brand = colors_brand_brand_dark_m3,
+    onBrand = colors_brand_on_brand_dark_m3,
+    brandContainer = colors_brand_brand_container_dark_m3,
+    onBrandContainer = colors_brand_on_brand_container_dark_m3
+)
+
 
 /**
  * Composition locals for custom success and warning colors.
@@ -291,11 +412,11 @@ val MaterialTheme.w3wColorScheme: W3WColorScheme
     @Composable
     @ReadOnlyComposable
     get() = LocalW3WColorScheme.current
-        ?: (if (isSystemInDarkTheme()) darkW3WColors else lightW3WColors)
+        ?: (if (isSystemInDarkTheme()) m3DarkW3WSchemeColors else m3LightW3WSchemeColors)
 
 //to be removed when updating material3 library
 val MaterialTheme.surfaceVariationsColors: SurfaceVariationsColors
     @Composable
     @ReadOnlyComposable
     get() = LocalSurfaceVariationsColors.current
-        ?: (if (isSystemInDarkTheme()) darkSurfaceVariationsColors else lightSurfaceVariationsColors)
+        ?: (if (isSystemInDarkTheme()) m3DarkSurfaceVariationsColors else m3LightSurfaceVariationsColors)

--- a/design-library/src/main/java/com/what3words/design/library/ui/theme/Theme.kt
+++ b/design-library/src/main/java/com/what3words/design/library/ui/theme/Theme.kt
@@ -33,9 +33,9 @@ fun W3WTheme(
     else w3wLightColors
 
     val surfaceVariants =
-        if (useDarkTheme) darkSurfaceVariationsColors else lightSurfaceVariationsColors
+        if (useDarkTheme) w3wDarkSurfaceVariationsColors else w3wLightSurfaceVariationsColors
 
-    val w3WColorScheme = if (useDarkTheme) darkW3WColors else lightW3WColors
+    val w3WColorScheme = if (useDarkTheme) w3wDarkW3WSchemeColors else w3wLightW3WSchemeColors
 
     // Customize typography for the What3words theme.
     val w3wTypography = W3wTypography(


### PR DESCRIPTION
changed variable names and added m3 colours because the design team now decided to give new colours for m3 for proprietary colours instead of defaulting to the w3w colours... this is new.

The new color names in general will help to work with a figma plugin to extract colours easily.